### PR TITLE
Fix resource robot gone amuck

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,7 +227,42 @@
       </plugin>
       <!-- Maven dependency helps freelib-resources copy files into the project -->
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-dependency-analyzer</artifactId>
+            <version>${maven.dependency.analyzer.version}</version>
+            <exclusions>
+              <exclusion>
+                <artifactId>maven-project</artifactId>
+                <groupId>org.apache.maven</groupId>
+              </exclusion>
+            </exclusions>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>unpack-build-resources</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>info.freelibrary</groupId>
+                  <artifactId>freelib-resources</artifactId>
+                  <version>${freelib.resources.version}</version>
+                  <type>jar</type>
+                  <includes>eclipse/**/*,checkstyle/**/*,pmd/**/*,travis/**/*</includes>
+                  <outputDirectory>${basedir}/target/build-resources</outputDirectory>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <!-- Surefire runs the project's tests -->
       <plugin>
@@ -245,12 +280,6 @@
           <argLine>${jacoco.agent.arg}</argLine>
         </configuration>
       </plugin>
-      <!--<![CDATA[ We're not going to use JBake for site generation now, but keeping for later...
-        <plugin>
-          <groupId>br.com.ingenieux</groupId>
-          <artifactId>jbake-maven-plugin</artifactId>
-        </plugin>
-      ]]>-->
       <!-- Jacoco does code coverage for the test suite -->
       <plugin>
         <groupId>org.jacoco</groupId>

--- a/src/test/resources/settings.xml
+++ b/src/test/resources/settings.xml
@@ -31,12 +31,12 @@
         <gpg.keyname>${env.BUILD_KEYNAME}</gpg.keyname>
         <gpg.passphrase>${env.BUILD_PASSPHRASE}</gpg.passphrase>
 
-        <!--
+        <!--<![CDATA[
         <bucketeer.s3.bucket></bucketeer.s3.bucket>
         <bucketeer.s3.access_key></bucketeer.s3.access_key>
         <bucketeer.s3.secret_key></bucketeer.s3.secret_key>
         <bucketeer.s3.region></bucketeer.s3.region>
-        -->
+        ]]>-->
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
The build was copying over a test settings.xml file which we'd normally want but in our case we want to put some additional S3 configuration information in there so we don't want that overridden. This commit disables that behavior by reconfiguring the resources plugin.