### PR TITLE
Don't package log config with jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,15 @@
   </dependencies>
 
   <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <excludes>
+          <exclude>logback.xml</exclude>
+          <exclude>checkstyle.xml</exclude>
+        </excludes>
+      </resource>
+    </resources>
     <testResources>
       <testResource>
         <directory>src/test/resources</directory>


### PR DESCRIPTION
In order to be able to use an external logging configuration, we need to stop packaging a default logging configuration in the Jar file. This didn't use to be true, but the never JDKs have obsoleted the `-Xbootclasspath/p:[PATH]` option, which is how we were overriding the default location in the jar file.

We'll be able to use `-Xbootclasspath/a` but we need to remove the packaged logging configuration file first. This is fine because we'll be able to supply a default config in the Docker build.