### PR TITLE
Improve error handling

### DIFF
--- a/src/main/java/edu/ucla/library/bucketeer/verticles/ImageWorkerVerticle.java
+++ b/src/main/java/edu/ucla/library/bucketeer/verticles/ImageWorkerVerticle.java
@@ -47,7 +47,7 @@ public class ImageWorkerVerticle extends AbstractBucketeerVerticle {
                 message.put(Constants.FILE_PATH, jpx.getAbsolutePath());
                 message.put(Constants.IMAGE_ID, jpx.getName());
 
-                sendMessage(message, S3BucketVerticle.class.getName());
+                sendMessage(message, S3BucketVerticle.class.getName(), Integer.MAX_VALUE);
             } catch (final Exception details) {
                 final String message = details.getMessage() != null ? details.getMessage() : LOGGER.getMessage(
                         MessageCodes.BUCKETEER_030);

--- a/src/main/java/edu/ucla/library/bucketeer/verticles/S3BucketVerticle.java
+++ b/src/main/java/edu/ucla/library/bucketeer/verticles/S3BucketVerticle.java
@@ -52,9 +52,9 @@ public class S3BucketVerticle extends AbstractBucketeerVerticle {
 
             myS3Client = new S3Client(getVertx(), s3AccessKey, s3SecretKey, s3Region);
 
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug(MessageCodes.BUCKETEER_009, s3RegionName);
-            }
+            // Trace is only for developer use; don't turn on when running on a server
+            LOGGER.trace(MessageCodes.BUCKETEER_045, s3AccessKey, s3SecretKey);
+            LOGGER.debug(MessageCodes.BUCKETEER_009, s3RegionName);
         }
 
         getJsonConsumer().handler(message -> {

--- a/src/main/java/edu/ucla/library/bucketeer/verticles/S3BucketVerticle.java
+++ b/src/main/java/edu/ucla/library/bucketeer/verticles/S3BucketVerticle.java
@@ -19,6 +19,7 @@ import edu.ucla.library.bucketeer.HTTP;
 import edu.ucla.library.bucketeer.MessageCodes;
 import edu.ucla.library.bucketeer.Op;
 import io.vertx.core.Vertx;
+import io.vertx.core.file.AsyncFile;
 import io.vertx.core.file.OpenOptions;
 import io.vertx.core.json.JsonObject;
 
@@ -62,13 +63,15 @@ public class S3BucketVerticle extends AbstractBucketeerVerticle {
             final String jpxPath = storageRequest.getString(Constants.FILE_PATH);
             final String s3Bucket = storageRequest.getString(Config.S3_BUCKET);
 
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug(MessageCodes.BUCKETEER_010, imageID, jpxPath, s3Bucket);
-            }
+            LOGGER.debug(MessageCodes.BUCKETEER_010, imageID, jpxPath, s3Bucket);
 
             vertx.fileSystem().open(jpxPath, new OpenOptions().setRead(true), open -> {
                 if (open.succeeded()) {
-                    myS3Client.put(s3Bucket, imageID, open.result(), response -> {
+                    final AsyncFile asyncFile = open.result();
+
+                    LOGGER.debug(MessageCodes.BUCKETEER_044, imageID, jpxPath, s3Bucket);
+
+                    myS3Client.put(s3Bucket, imageID, asyncFile, response -> {
                         final int statusCode = response.statusCode();
 
                         // If we get a successful upload response code, note this in our results map
@@ -80,7 +83,12 @@ public class S3BucketVerticle extends AbstractBucketeerVerticle {
                             LOGGER.error(MessageCodes.BUCKETEER_014, statusCode, response.statusMessage());
                             message.reply(Op.FAILURE);
                         }
+
+                        asyncFile.close();
                     });
+                } else {
+                    LOGGER.error(open.cause(), LOGGER.getMessage(MessageCodes.BUCKETEER_043, jpxPath));
+                    message.reply(Op.FAILURE);
                 }
             });
 

--- a/src/main/resources/bucketeer_messages.xml
+++ b/src/main/resources/bucketeer_messages.xml
@@ -54,4 +54,6 @@
   <entry key="BUCKETEER-040"> --> Bucket ({}) does not exist!</entry>
   <entry key="BUCKETEER-041"> --> JP2 ({}) does not exist!</entry>
   <entry key="BUCKETEER-042"> --> JP2 ({}) has a length of zero!</entry>
+  <entry key="BUCKETEER-043">Failed to read JPX file: {}</entry>
+  <entry key="BUCKETEER-044">Sending '{}' [{}] to S3 bucket: {}</entry>
 </properties>

--- a/src/main/resources/bucketeer_messages.xml
+++ b/src/main/resources/bucketeer_messages.xml
@@ -56,4 +56,5 @@
   <entry key="BUCKETEER-042"> --> JP2 ({}) has a length of zero!</entry>
   <entry key="BUCKETEER-043">Failed to read JPX file: {}</entry>
   <entry key="BUCKETEER-044">Sending '{}' [{}] to S3 bucket: {}</entry>
+  <entry key="BUCKETEER-045">AWS S3 access / secret keys: {} / {}</entry>
 </properties>


### PR DESCRIPTION
* Add better debugging and handle a possible exception that could be thrown if the JPX file can't be read from the local file system for some obscure reason.
* Extend timeout on message response from S3BucketVerticle. This could probably be rewritten to not reply with a response at all, since the message sender is not actually waiting on a response, but that's a future ticket.

This is in support of IIIF-289 but doesn't close it or anything, is just incremental progress.