### PR TITLE
[IIIF-295] Optimize docker build trigger and accept tagged jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,29 +10,36 @@ install:
 script:
 - mvn verify -Dbucketeer.s3.access_key="$AWS_ACCESS_KEY_ID" -Dbucketeer.s3.secret_key="$AWS_SECRET_ACCESS_KEY"
 
-# We want all PRs built but only merges on master branch
-#  However, when we first create a new project, we need to comment this out
+# We want all PRs built but only merges on master branch and tags under semantic version scheme
 branches:
   only:
   - master
+  - /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$/
 
-after_success:
-- |
-  # The following vars are stored encrypted in TravisCI
-  # JENKINS_USER
-  # JENKINS_USER_PASS
-  # JENKINS_URL
-
-  # Trigger latest dockerhub build if commit on master branch
-  if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then
-    curl -I -u "${JENKINS_USER}:${JENKINS_USER_PASS}" "${JENKINS_URL}"
-  # Else if there's a tag, trigger a tag build
-  elif [[ $TRAVIS_TAG != "" && $TRAVIS_PULL_REQUEST == 'false' ]]; then
-    curl -I -u "${JENKINS_USER}:${JENKINS_USER_PASS}" "${JENKINS_URL}&BUCKETEER_VERSION=${TRAVIS_TAG}"
-  # Else we're assuming this is using another branch other than master
-  elif [[ $TRAVIS_BRANCH != "master" && $TRAVIS_PULL_REQUEST == 'false' && $TRAVIS_TAG == "" ]]; then
-    curl -I -u "${JENKINS_USER}:${JENKINS_USER_PASS}" "${JENKINS_URL}&BUCKETEER_VERSION=${TRAVIS_BRANCH}"
-  fi
+jobs:
+  include:
+    - stage: Deploy Latest Build
+      name: Trigger Docker Latest Build
+      language: minimal
+      # This install line must be kept here to override the global install call. Maven is not installed in the minimal containers
+      install: which curl
+      deploy:
+        - provider: script
+          script: ./trigger-docker-build.sh
+          on:
+            branch: master
+      if: (NOT type IN (pull_request)) AND (branch = master)
+    - stage: Deploy Tag Build
+      name: Trigger Docker Tag Build
+      language: minimal
+      # This install line must be kept here to override the global install call. Maven is not installed in the minimal containers
+      install: which curl
+      deploy:
+        - provider: script
+          script: ./trigger-docker-build.sh
+          on:
+            tags: true
+      if: (NOT type IN (pull_request)) AND (branch =~ /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$/)
 
 notifications:
   email:

--- a/trigger-docker-build.sh
+++ b/trigger-docker-build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# The following vars are stored encrypted in TravisCI
+# JENKINS_USER
+# JENKINS_USER_PASS
+# JENKINS_URL
+
+# Trigger latest dockerhub build if commit is on master branch
+if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then
+  curl -I -u "${JENKINS_USER}:${JENKINS_USER_PASS}" "${JENKINS_URL}"
+  # Else if it's a tag, trigger a tag build
+elif [[ $TRAVIS_TAG != "" && $TRAVIS_PULL_REQUEST == 'false' ]]; then
+  curl -I -u "${JENKINS_USER}:${JENKINS_USER_PASS}" "${JENKINS_URL}&BUCKETEER_VERSION=${TRAVIS_TAG}"
+  # Else we're assuming this is using another branch other than master
+elif [[ $TRAVIS_BRANCH != "master" && $TRAVIS_PULL_REQUEST == 'false' && $TRAVIS_TAG == "" ]]; then
+  curl -I -u "${JENKINS_USER}:${JENKINS_USER_PASS}" "${JENKINS_URL}&BUCKETEER_VERSION=${TRAVIS_BRANCH}"
+fi


### PR DESCRIPTION
This PR aims to fix and improve the following features:

* TravisCI is only configured to run on PRs and master branch. The new PR will accept requests for tags under the semantic version scheme(without the prepended v in front of the numbers, e.g. 1.0.0)
* After success triggered on the each matrix build, which meant 2 curl jobs would run. I moved to using stage builds which runs independently from other matrix builds
* I optimized the stage builds to run stages only when necessary. E.g. it skips the deploy stages if it's a PR build, skips the latest build if it's a tag build, etc.
* Merging this PR would officially enable automatic triggers to the Jenkins/Codebuild pipeline